### PR TITLE
Migrate to Figure Tech

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Provenance Blockchain, Inc
+   Copyright 2022 Figure Technologies
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ These core components comprise the baseline needed for generating new [Provenanc
 [![Maven Central][maven-badge]][maven-url]
 [![Apache 2.0 License][license-badge]][license-url]
 
-[license-badge]: https://img.shields.io/github/license/provenance-io/asset-specifications.svg
-[license-url]: https://github.com/provenance-io/asset-specifications/blob/main/LICENSE
-[maven-badge]: https://maven-badges.herokuapp.com/maven-central/io.provenance.spec/asset-specs/badge.svg
-[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.provenance.spec/asset-specs
-[release-badge]: https://img.shields.io/github/tag/provenance-io/asset-specifications.svg
-[release-latest]: https://github.com/provenance-io/asset-specifications/releases/latest
+[license-badge]: https://img.shields.io/github/license/FigureTechnologies/asset-specifications.svg
+[license-url]: https://github.com/FigureTechnologies/asset-specifications/blob/main/LICENSE
+[maven-badge]: https://maven-badges.herokuapp.com/maven-central/tech.figure.spec/asset-specs/badge.svg
+[maven-url]: https://maven-badges.herokuapp.com/maven-central/tech.figure.spec/asset-specs
+[release-badge]: https://img.shields.io/github/tag/FigureTechnologies/asset-specifications.svg
+[release-latest]: https://github.com/FigureTechnologies/asset-specifications/releases/latest
 
 ### Specifications on Testnet
 
@@ -42,18 +42,18 @@ Shareclass NFT: https://explorer.test.provenance.io/nft/c328573f-08cd-4cd8-956d-
 ### Using the asset-specs library
 
 To create Provenance Blockchain msg protos that will onboard a scope specification, simply use the provided
-[AssetSpecifications](specs/src/main/kotlin/io/provenance/spec/AssetSpecification.kt/) object, or refer to a specification
+[AssetSpecifications](specs/src/main/kotlin/tech/figure/spec/AssetSpecification.kt/) object, or refer to a specification
 directly:
 
 ```kotlin
 import com.google.protobuf.Message
 import io.provenance.scope.util.toUuid
-import io.provenance.spec.AssetSpecification
-import io.provenance.spec.AssetSpecifications
-import io.provenance.spec.ContractSpecConfig
-import io.provenance.spec.HELOCSpecification
-import io.provenance.spec.RecordSpecConfig
-import io.provenance.spec.ScopeSpecConfig
+import tech.figure.spec.AssetSpecification
+import tech.figure.spec.AssetSpecifications
+import tech.figure.spec.ContractSpecConfig
+import tech.figure.spec.HELOCSpecification
+import tech.figure.spec.RecordSpecConfig
+import tech.figure.spec.ScopeSpecConfig
 
 // To generate all messages, owned by the same address
 fun generateAllSpecificationMessages(specOwnerBech32Address: String): List<Message> = AssetSpecifications

--- a/README.md
+++ b/README.md
@@ -20,20 +20,6 @@ These core components comprise the baseline needed for generating new [Provenanc
 [release-badge]: https://img.shields.io/github/tag/FigureTechnologies/asset-specifications.svg
 [release-latest]: https://github.com/FigureTechnologies/asset-specifications/releases/latest
 
-### Specifications on Testnet
-
-https://explorer.test.provenance.io/tx/E1B42D0ACCA2E6674E652C88CA3DC57789A5881558B4D46C91F149244D068BF8
-
-NFT Examples: 
-
-Collectable NFT: https://explorer.test.provenance.io/nft/78f034ed-9b7e-4a6e-af14-986bf41d2478
-HELOC NFT: https://explorer.test.provenance.io/nft/985bd660-6d5a-4400-8de2-502830208121
-Mortgage NFT: https://explorer.test.provenance.io/nft/ed14f4af-217c-48f9-8082-25ccf3547b33
-Payable NFT: https://explorer.test.provenance.io/nft/bce44beb-e4e6-4115-8660-f20687b23da4
-Personal Loan NFT: https://explorer.test.provenance.io/nft/8972656d-cd13-4a5d-86d0-942e2a9f0b
-Property NFT: https://explorer.test.provenance.io/nft/9704e06c-43fe-4db9-bc27-bcb2d7fe54bb
-Shareclass NFT: https://explorer.test.provenance.io/nft/c328573f-08cd-4cd8-956d-22d6ab45875c
-
 ### Release Process
 - All new features merge to develop
 - Code ready for release merges to main

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ configure<io.github.gradlenexus.publishplugin.NexusPublishExtension> {
             snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
             username.set(findProject("ossrhUsername")?.toString() ?: System.getenv("OSSRH_USERNAME"))
             password.set(findProject("ossrhPassword")?.toString() ?: System.getenv("OSSRH_PASSWORD"))
-            stagingProfileId.set("3180ca260b82a7") // prevents querying for the staging profile id, performance optimization
+            stagingProfileId.set("858b6e4de4734a") // tech.figure staging profile id
         }
     }
 }

--- a/buildSrc/src/main/kotlin/core-config.gradle.kts
+++ b/buildSrc/src/main/kotlin/core-config.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("java-library")
 }
 
-group = "io.provenance.spec"
+group = "tech.figure.spec"
 version = project.property("version")?.takeIf { it != "unspecified" } ?: "1.0-SNAPSHOT"
 
 repositories {

--- a/specs/build.gradle.kts
+++ b/specs/build.gradle.kts
@@ -27,9 +27,9 @@ configure<PublishingExtension> {
             from(components["java"])
 
             pom {
-                name.set("Provenance Asset Specifications")
+                name.set("Figure Technologies Asset Specifications")
                 description.set("Scope specifications for classifying various types of Asset proto")
-                url.set("https://provenance.io")
+                url.set("https://figure.tech")
                 licenses {
                     license {
                         name.set("The Apache License, Version 2.0")
@@ -51,9 +51,9 @@ configure<PublishingExtension> {
                 }
 
                 scm {
-                    developerConnection.set("git@github.com:provenance.io/asset-specifications")
-                    connection.set("https://github.com/provenance-io/asset-specifications.git")
-                    url.set("https://github.com/provenance-io/asset-specifications")
+                    developerConnection.set("git@github.com:FigureTechnologies/asset-specifications")
+                    connection.set("https://github.com/FigureTechnologies/asset-specifications.git")
+                    url.set("https://github.com/FigureTechnologies/asset-specifications")
                 }
             }
         }

--- a/specs/src/main/kotlin/tech/figure/spec/AssetSpecification.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/AssetSpecification.kt
@@ -1,6 +1,6 @@
-package io.provenance.spec
+package tech.figure.spec
 
-import io.provenance.spec.util.SpecBuilder
+import tech.figure.spec.util.SpecBuilder
 
 val AssetSpecifications: List<AssetSpecification> = listOf(
     CollectableSpecification,
@@ -11,7 +11,6 @@ val AssetSpecifications: List<AssetSpecification> = listOf(
     PropertySpecification,
     ShareclassSpecification
 )
-
 
 interface AssetSpecification {
 

--- a/specs/src/main/kotlin/tech/figure/spec/CollectableSpecification.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/CollectableSpecification.kt
@@ -1,29 +1,29 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import io.provenance.scope.util.toUuid
 
 object CollectableSpecification : AssetSpecification {
 
     override val scopeSpecConfig = ScopeSpecConfig(
-        id = "6efad216-5a9a-4c7d-b3e9-7e4550ca8cf2".toUuid(),
+        id = "060e0cec-27eb-11ed-b329-3b1a158b3efa".toUuid(),
         name = "Collectable NFT",
-        description = "Collectable NFT Specification provided by the Provenance Blockchain Foundation",
+        description = "Collectable NFT Specification provided by Figure Technologies",
         websiteUrl = websiteUrl
     )
 
     override val contractSpecConfigs = listOf(
         ContractSpecConfig(
-            id = "1bef03c6-3f86-481b-927b-5dbec22a7ab2".toUuid(),
-            contractClassname = "io.provenance.spec.OnboardCollectableContractSpec",
+            id = "0acf25fe-27eb-11ed-a462-632414f7f96f".toUuid(),
+            contractClassname = "tech.figure.spec.OnboardCollectableContractSpec",
             name = "Onboard Collectable NFT",
-            description = "Mint Collectable NFT Contract Specification provided by the Provenance Blockchain Foundation",
+            description = "Mint Collectable NFT Contract Specification provided by Figure Technologies",
             websiteUrl = websiteUrl
         )
     )
 
     override val recordSpecConfigs = listOf(
         RecordSpecConfig(
-            id = "73fdbb5d-4234-40e6-abef-dd6c044b4237".toUuid(),
+            id = "0f569972-27eb-11ed-a208-934170c51a60".toUuid(),
             name = "collectable",
             typeClassname = "io.provenance.model.v1.Asset",
             contractSpecId = contractSpecConfigs.first().id

--- a/specs/src/main/kotlin/tech/figure/spec/ContractSpecConfig.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/ContractSpecConfig.kt
@@ -1,4 +1,4 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import java.util.UUID
 
@@ -25,4 +25,4 @@ data class RecordSpecConfig(
     val contractSpecId: UUID
 )
 
-const val websiteUrl = "https://github.com/provenance-io/asset-specifications"
+const val websiteUrl = "https://github.com/FigureTechnologies/asset-specifications"

--- a/specs/src/main/kotlin/tech/figure/spec/HelocSpecification.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/HelocSpecification.kt
@@ -1,29 +1,29 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import io.provenance.scope.util.toUuid
 
 object HELOCSpecification : AssetSpecification {
 
     override val scopeSpecConfig = ScopeSpecConfig(
-        id = "7205eaf2-4e1c-486c-a5f2-c0794f28a780".toUuid(),
+        id = "19e637d0-27eb-11ed-9c63-878b98ca90d8".toUuid(),
         name = "HELOC NFT",
-        description = "HELOC NFT Specification provided by the Provenance Blockchain Foundation",
+        description = "HELOC NFT Specification provided by Figure Technologies",
         websiteUrl = websiteUrl
     )
 
     override val contractSpecConfigs = listOf(
         ContractSpecConfig(
-            id = "95732991-f4f2-4e1b-8022-43d150031315".toUuid(),
-            contractClassname = "io.provenance.spec.OnboardHELOCContractSpec",
+            id = "1e769c7c-27eb-11ed-b7e1-8bcc0de384bd".toUuid(),
+            contractClassname = "tech.figure.spec.OnboardHELOCContractSpec",
             name = "Onboard HELOC NFT",
-            description = "Mint HELOC NFT Contract Specification provided by the Provenance Blockchain Foundation",
+            description = "Mint HELOC NFT Contract Specification provided by Figure Technologies",
             websiteUrl = websiteUrl
         )
     )
 
     override val recordSpecConfigs = listOf(
         RecordSpecConfig(
-            id = "d93e855e-a1aa-4f40-a653-34e89272d845".toUuid(),
+            id = "2d36b1ca-27eb-11ed-8e75-cf2150f5e5e4".toUuid(),
             name = "heloc",
             typeClassname = "io.provenance.model.v1.Asset",
             contractSpecId = contractSpecConfigs.first().id

--- a/specs/src/main/kotlin/tech/figure/spec/MortgageSpecification.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/MortgageSpecification.kt
@@ -1,29 +1,29 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import io.provenance.scope.util.toUuid
 
 object MortgageSpecification : AssetSpecification {
 
     override val scopeSpecConfig = ScopeSpecConfig(
-        id = "86fef324-a9d0-4d00-ae2f-e03a85c8224c".toUuid(),
+        id = "388b1b06-27eb-11ed-97d9-7fe43d2b97ee".toUuid(),
         name = "Mortgage NFT",
-        description = "Mortgage NFT Specification provided by the Provenance Blockchain Foundation",
+        description = "Mortgage NFT Specification provided by Figure Technologies",
         websiteUrl = websiteUrl
     )
 
     override val contractSpecConfigs = listOf(
         ContractSpecConfig(
-            id = "f4ac5c9c-a220-4403-85d3-9f0eb62b8bc1".toUuid(),
-            contractClassname = "io.provenance.spec.OnboardMortgageContractSpec",
+            id = "3c214c40-27eb-11ed-bc9d-e351c32eedf0".toUuid(),
+            contractClassname = "tech.figure.spec.OnboardMortgageContractSpec",
             name = "Onboard Mortgage NFT",
-            description = "Mint Mortgage NFT Contract Specification provided by the Provenance Blockchain Foundation",
+            description = "Mint Mortgage NFT Contract Specification provided by Figure Technologies",
             websiteUrl = websiteUrl
         )
     )
 
     override val recordSpecConfigs = listOf(
         RecordSpecConfig(
-            id = "25bb5aa7-8bbe-43d6-a48c-900c0b772ed1".toUuid(),
+            id = "415c13e8-27eb-11ed-ae35-931d15348812".toUuid(),
             name = "mortgage",
             typeClassname = "io.provenance.model.v1.Asset",
             contractSpecId = contractSpecConfigs.first().id

--- a/specs/src/main/kotlin/tech/figure/spec/PayableSpecification.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/PayableSpecification.kt
@@ -1,29 +1,29 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import io.provenance.scope.util.toUuid
 
 object PayableSpecification : AssetSpecification {
 
     override val scopeSpecConfig = ScopeSpecConfig(
-        id = "11e7d541-a120-48a7-98c5-e32b8aa0707f".toUuid(),
+        id = "47716634-27eb-11ed-81d5-877cf2b20ca6".toUuid(),
         name = "Payable NFT",
-        description = "Payable NFT Specification provided by the Provenance Blockchain Foundation",
+        description = "Payable NFT Specification provided by Figure Technologies",
         websiteUrl = websiteUrl
     )
 
     override val contractSpecConfigs = listOf(
         ContractSpecConfig(
-            id = "a965a903-af84-4322-a645-d11ceb55c17f".toUuid(),
-            contractClassname = "io.provenance.spec.OnboardPayableContractSpec",
+            id = "4b44ffdc-27eb-11ed-bef5-53479060599c".toUuid(),
+            contractClassname = "tech.figure.spec.OnboardPayableContractSpec",
             name = "Onboard Payable NFT",
-            description = "Mint Payable NFT Contract Specification provided by the Provenance Blockchain Foundation",
+            description = "Mint Payable NFT Contract Specification provided by Figure Technologies",
             websiteUrl = websiteUrl
         )
     )
 
     override val recordSpecConfigs = listOf(
         RecordSpecConfig(
-            id = "2bd4e986-0964-46bb-a8b3-8d4989a287e2".toUuid(),
+            id = "4f7dc4d0-27eb-11ed-a8fb-33003bfde41f".toUuid(),
             name = "payable",
             typeClassname = "io.provenance.model.v1.Asset",
             contractSpecId = contractSpecConfigs.first().id

--- a/specs/src/main/kotlin/tech/figure/spec/PersonalLoanSpecification.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/PersonalLoanSpecification.kt
@@ -1,29 +1,29 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import io.provenance.scope.util.toUuid
 
 object PersonalLoanSpecification : AssetSpecification {
 
     override val scopeSpecConfig = ScopeSpecConfig(
-        id = "61ca59d2-7a11-4ca7-8035-eef698656dc8".toUuid(),
+        id = "54c4b26e-27eb-11ed-8c87-53fbe8bf8d09".toUuid(),
         name = "Personal Loan NFT",
-        description = "Personal Loan NFT Specification provided by the Provenance Blockchain Foundation",
+        description = "Personal Loan NFT Specification provided by Figure Technologies",
         websiteUrl = websiteUrl
     )
 
     override val contractSpecConfigs = listOf(
         ContractSpecConfig(
-            id = "746b698c-f63d-489e-9b42-8c61a7316c62".toUuid(),
-            contractClassname = "io.provenance.spec.OnboardPersonal LoanContractSpec",
+            id = "57cab698-27eb-11ed-b4db-9b502cfcbe6a".toUuid(),
+            contractClassname = "tech.figure.spec.OnboardPersonalLoanContractSpec",
             name = "Onboard Personal Loan NFT",
-            description = "Mint Personal Loan NFT Contract Specification provided by the Provenance Blockchain Foundation",
+            description = "Mint Personal Loan NFT Contract Specification provided by Figure Technologies",
             websiteUrl = websiteUrl
         )
     )
 
     override val recordSpecConfigs = listOf(
         RecordSpecConfig(
-            id = "93c4af8a-fa32-4bd9-8207-005fd52bcbda".toUuid(),
+            id = "5d00931c-27eb-11ed-9e62-3369af5209b7".toUuid(),
             name = "personalLoan",
             typeClassname = "io.provenance.model.v1.Asset",
             contractSpecId = contractSpecConfigs.first().id

--- a/specs/src/main/kotlin/tech/figure/spec/PropertySpecification.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/PropertySpecification.kt
@@ -1,29 +1,29 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import io.provenance.scope.util.toUuid
 
 object PropertySpecification : AssetSpecification {
 
     override val scopeSpecConfig = ScopeSpecConfig(
-        id = "79c47c7b-9206-470c-b9bc-f6d80e1ffdda".toUuid(),
+        id = "60e391fa-27eb-11ed-94ca-ef8743476060".toUuid(),
         name = "Property NFT",
-        description = "Property NFT Specification provided by the Provenance Blockchain Foundation",
+        description = "Property NFT Specification provided by Figure Technologies",
         websiteUrl = websiteUrl
     )
 
     override val contractSpecConfigs = listOf(
         ContractSpecConfig(
-            id = "ffe52f9c-482f-439c-8788-ad20cdf14338".toUuid(),
-            contractClassname = "io.provenance.spec.OnboardPropertyContractSpec",
+            id = "65e7ee26-27eb-11ed-bd26-f3053634bbb5".toUuid(),
+            contractClassname = "tech.figure.spec.OnboardPropertyContractSpec",
             name = "Onboard Property NFT",
-            description = "Mint Property NFT Contract Specification provided by the Provenance Blockchain Foundation",
+            description = "Mint Property NFT Contract Specification provided by Figure Technologies",
             websiteUrl = websiteUrl
         )
     )
 
     override val recordSpecConfigs = listOf(
         RecordSpecConfig(
-            id = "8b834744-01a4-4638-9261-cc4b2e19dd9b".toUuid(),
+            id = "69d9770c-27eb-11ed-ad3e-1b3d0349f661".toUuid(),
             name = "property",
             typeClassname = "io.provenance.model.v1.Asset",
             contractSpecId = contractSpecConfigs.first().id

--- a/specs/src/main/kotlin/tech/figure/spec/ShareclassSpecification.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/ShareclassSpecification.kt
@@ -1,29 +1,29 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import io.provenance.scope.util.toUuid
 
 object ShareclassSpecification : AssetSpecification {
 
     override val scopeSpecConfig = ScopeSpecConfig(
-        id = "60980579-7533-40be-a4d6-31659806d54e".toUuid(),
+        id = "6d20aef8-27eb-11ed-b0a8-bbd2b8165ad5".toUuid(),
         name = "Shareclass NFT",
-        description = "Shareclass NFT Specification provided by the Provenance Blockchain Foundation",
+        description = "Shareclass NFT Specification provided by Figure Technologies",
         websiteUrl = websiteUrl
     )
 
     override val contractSpecConfigs = listOf(
         ContractSpecConfig(
-            id = "a1c11ddf-b9c7-41fd-b1c6-bb538a93480c".toUuid(),
-            contractClassname = "io.provenance.spec.OnboardShareclassContractSpec",
+            id = "715859b2-27eb-11ed-a379-2f6c527c4240".toUuid(),
+            contractClassname = "tech.figure.spec.OnboardShareclassContractSpec",
             name = "Onboard Shareclass NFT",
-            description = "Mint Shareclass NFT Contract Specification provided by the Provenance Blockchain Foundation",
+            description = "Mint Shareclass NFT Contract Specification provided by Figure Technologies",
             websiteUrl = websiteUrl
         )
     )
 
     override val recordSpecConfigs = listOf(
         RecordSpecConfig(
-            id = "ee9ec648-c136-4a37-96dd-5a672a205000".toUuid(),
+            id = "7487e74c-27eb-11ed-aacb-bfec8a5afd5f".toUuid(),
             name = "shareclass",
             typeClassname = "io.provenance.model.v1.Asset",
             contractSpecId = contractSpecConfigs.first().id

--- a/specs/src/main/kotlin/tech/figure/spec/util/SpecBuilder.kt
+++ b/specs/src/main/kotlin/tech/figure/spec/util/SpecBuilder.kt
@@ -1,4 +1,4 @@
-package io.provenance.spec.util
+package tech.figure.spec.util
 
 import com.google.protobuf.Message
 import io.provenance.metadata.v1.DefinitionType
@@ -9,9 +9,9 @@ import io.provenance.metadata.v1.MsgWriteScopeSpecificationRequest
 import io.provenance.metadata.v1.PartyType
 import io.provenance.scope.util.MetadataAddress
 import io.provenance.scope.util.toByteString
-import io.provenance.spec.ContractSpecConfig
-import io.provenance.spec.RecordSpecConfig
-import io.provenance.spec.ScopeSpecConfig
+import tech.figure.spec.ContractSpecConfig
+import tech.figure.spec.RecordSpecConfig
+import tech.figure.spec.ScopeSpecConfig
 
 object SpecBuilder {
 

--- a/util/src/main/kotlin/tech/figure/spec/Main.kt
+++ b/util/src/main/kotlin/tech/figure/spec/Main.kt
@@ -1,4 +1,4 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import com.google.protobuf.ByteString
 import cosmos.crypto.secp256k1.Keys
@@ -13,7 +13,7 @@ import io.provenance.hdwallet.bip39.MnemonicWords
 import io.provenance.hdwallet.wallet.Account
 import io.provenance.hdwallet.wallet.Wallet
 import io.provenance.scope.util.ProtoJsonUtil.toJson
-import io.provenance.spec.util.ProvenanceNetworkType
+import tech.figure.spec.util.ProvenanceNetworkType
 import java.net.URI
 
 /*

--- a/util/src/main/kotlin/tech/figure/spec/TestNFTs.kt
+++ b/util/src/main/kotlin/tech/figure/spec/TestNFTs.kt
@@ -1,4 +1,4 @@
-package io.provenance.spec
+package tech.figure.spec
 
 import com.google.protobuf.ByteString
 import com.google.protobuf.Message
@@ -17,7 +17,7 @@ import io.provenance.metadata.v1.*
 import io.provenance.scope.util.MetadataAddress
 import io.provenance.scope.util.ProtoJsonUtil.toJson
 import io.provenance.scope.util.toByteString
-import io.provenance.spec.util.ProvenanceNetworkType
+import tech.figure.spec.util.ProvenanceNetworkType
 import java.net.URI
 import java.util.*
 

--- a/util/src/main/kotlin/tech/figure/spec/util/ProvenanceNetworkType.kt
+++ b/util/src/main/kotlin/tech/figure/spec/util/ProvenanceNetworkType.kt
@@ -1,4 +1,4 @@
-package io.provenance.spec.util
+package tech.figure.spec.util
 
 import io.provenance.client.wallet.NetworkType
 import io.provenance.hdwallet.hrp.Hrp


### PR DESCRIPTION
This PR changes all package names to conform to the new location of `tech.figure`, as well as assigning new uuid values to each definition to ensure they can be re-created with the Figure Technologies moniker. 